### PR TITLE
Fix frontend type errors and add shared utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/
+!frontend/src/lib/**
 lib64/
 parts/
 sdist/

--- a/frontend/src/components/documents/__tests__/DocumentUpload.test.tsx
+++ b/frontend/src/components/documents/__tests__/DocumentUpload.test.tsx
@@ -30,7 +30,7 @@ describe('DocumentUpload', () => {
     ;(useToast as any).mockReturnValue({
       addToast: mockAddToast,
     })
-    ;(api.post as any).mockResolvedValue({ data: { id: '123', filename: 'test.pdf' } })
+    ;(api.post as any).mockResolvedValue({ id: '123', filename: 'test.pdf' })
   })
 
   afterEach(() => {
@@ -108,7 +108,7 @@ describe('DocumentUpload', () => {
     const mockFile = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
     
     // Mock API success
-    vi.mocked(api.post).mockResolvedValue({ data: { id: '123', filename: 'test.pdf' } })
+    vi.mocked(api.post).mockResolvedValue({ id: '123', filename: 'test.pdf' })
     
     render(<DocumentUpload />)
     
@@ -138,7 +138,7 @@ describe('DocumentUpload', () => {
     // Mock API to fail first, then succeed
     vi.mocked(api.post)
       .mockRejectedValueOnce(new Error('Upload failed'))
-      .mockResolvedValueOnce({ data: { id: '123', filename: 'test.pdf' } })
+      .mockResolvedValueOnce({ id: '123', filename: 'test.pdf' })
     
     render(<DocumentUpload />)
     

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,71 @@
+import axios, {
+  type AxiosInstance,
+  type AxiosProgressEvent,
+  type AxiosRequestConfig,
+  isAxiosError,
+} from 'axios'
+
+const defaultBaseUrl = '/api'
+
+const client: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? defaultBaseUrl,
+  withCredentials: true,
+})
+
+const unwrap = async <T>(promise: Promise<{ data: T }>): Promise<T> => {
+  const response = await promise
+  return response.data
+}
+
+const withProgress = (
+  onProgress?: (progress: number) => void
+): ((event: AxiosProgressEvent) => void) | undefined => {
+  if (!onProgress) {
+    return undefined
+  }
+
+  return (event: AxiosProgressEvent) => {
+    if (!event.total) {
+      return
+    }
+
+    const progress = Math.round((event.loaded * 100) / event.total)
+    onProgress(progress)
+  }
+}
+
+export const api = {
+  get: <T>(url: string, config?: AxiosRequestConfig) => unwrap<T>(client.get<T>(url, config)),
+  post: <T, B = unknown>(url: string, data?: B, config?: AxiosRequestConfig) =>
+    unwrap<T>(client.post<T>(url, data, config)),
+  put: <T, B = unknown>(url: string, data?: B, config?: AxiosRequestConfig) =>
+    unwrap<T>(client.put<T>(url, data, config)),
+  patch: <T, B = unknown>(url: string, data?: B, config?: AxiosRequestConfig) =>
+    unwrap<T>(client.patch<T>(url, data, config)),
+  delete: <T = void>(url: string, config?: AxiosRequestConfig) =>
+    unwrap<T>(client.delete<T>(url, config)),
+  upload: async <T>(
+    url: string,
+    payload: FormData | File,
+    onProgress?: (progress: number) => void,
+    config?: AxiosRequestConfig<FormData>
+  ): Promise<T> => {
+    const body = payload instanceof FormData ? payload : (() => {
+      const formData = new FormData()
+      formData.append('file', payload)
+      return formData
+    })()
+
+    const response = await client.post<T>(url, body, {
+      ...config,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        ...config?.headers,
+      },
+      onUploadProgress: withProgress(onProgress),
+    })
+
+    return response.data
+  },
+  isAxiosError,
+}

--- a/frontend/src/lib/query-client.ts
+++ b/frontend/src/lib/query-client.ts
@@ -1,0 +1,14 @@
+export const queryKeys = {
+  domains: ['domains'] as const,
+  domain: (id: string) => ['domains', id] as const,
+  documents: ['documents'] as const,
+  chats: ['chats'] as const,
+}
+
+export const mutationKeys = {
+  createDomain: ['domains', 'create'] as const,
+  deleteDomain: (id: string) => ['domains', 'delete', id] as const,
+  uploadDocument: ['documents', 'upload'] as const,
+  deleteDocument: (id: string) => ['documents', 'delete', id] as const,
+  deleteChat: (id: string) => ['chats', 'delete', id] as const,
+}

--- a/frontend/src/lib/router.tsx
+++ b/frontend/src/lib/router.tsx
@@ -1,0 +1,42 @@
+import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom'
+import { Layout } from '@/components/layout/Layout'
+import { Dashboard } from '@/pages/Dashboard'
+import { EnhancedDashboard } from '@/pages/EnhancedDashboard'
+import { Domains } from '@/pages/Domains'
+import { DomainDetails } from '@/pages/DomainDetails'
+import { Documents } from '@/pages/Documents'
+import { DocumentDetails } from '@/pages/DocumentDetails'
+import { Chats } from '@/pages/Chats'
+import { ChatDetails } from '@/pages/ChatDetails'
+import { Search } from '@/pages/Search'
+import { RAG } from '@/pages/RAG'
+import { ExternalModels } from '@/pages/ExternalModels'
+import { Settings } from '@/pages/Settings'
+import { StyleGuide } from '@/pages/StyleGuide'
+import { NotFound } from '@/pages/NotFound'
+import { routes } from './routes'
+
+const trimLeadingSlash = (path: string) => path.replace(/^\//, '')
+
+export const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path={routes.home} element={<Layout />}>
+      <Route index element={<EnhancedDashboard />} />
+      <Route path={trimLeadingSlash(routes.dashboard)} element={<Dashboard />} />
+      <Route path={trimLeadingSlash(routes.enhancedDashboard)} element={<EnhancedDashboard />} />
+      <Route path={trimLeadingSlash(routes.domains)} element={<Domains />} />
+      <Route path={trimLeadingSlash(routes.domainDetails())} element={<DomainDetails />} />
+      <Route path={trimLeadingSlash(routes.documents)} element={<Documents />} />
+      <Route path={trimLeadingSlash(routes.documentDetails())} element={<DocumentDetails />} />
+      <Route path={trimLeadingSlash(routes.chats)} element={<Chats />} />
+      <Route path={trimLeadingSlash(routes.chat)} element={<ChatDetails />} />
+      <Route path={trimLeadingSlash(routes.chatDetails())} element={<ChatDetails />} />
+      <Route path={trimLeadingSlash(routes.search)} element={<Search />} />
+      <Route path={trimLeadingSlash(routes.rag)} element={<RAG />} />
+      <Route path={trimLeadingSlash(routes.externalModels)} element={<ExternalModels />} />
+      <Route path={trimLeadingSlash(routes.settings)} element={<Settings />} />
+      <Route path={trimLeadingSlash(routes.styleGuide)} element={<StyleGuide />} />
+      <Route path={routes.notFound} element={<NotFound />} />
+    </Route>
+  )
+)

--- a/frontend/src/lib/routes.ts
+++ b/frontend/src/lib/routes.ts
@@ -1,0 +1,22 @@
+const withId = (base: string) => (id = ':id') => `${base}/${id}`
+
+export const routes = {
+  home: '/',
+  dashboard: '/dashboard',
+  enhancedDashboard: '/dashboard/enhanced',
+  domains: '/domains',
+  domainDetails: withId('/domains'),
+  documents: '/documents',
+  documentDetails: withId('/documents'),
+  chats: '/chats',
+  chat: '/chat',
+  chatDetails: withId('/chats'),
+  rag: '/rag',
+  search: '/search',
+  externalModels: '/external-models',
+  settings: '/settings',
+  styleGuide: '/style-guide',
+  notFound: '*',
+} as const
+
+export type Routes = typeof routes

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * Merge Tailwind CSS class names while preserving the intended precedence.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(...inputs))
+}

--- a/frontend/src/pages/Chats.tsx
+++ b/frontend/src/pages/Chats.tsx
@@ -40,7 +40,7 @@ export const Chats: React.FC = () => {
   const queryClient = useQueryClient()
 
   // Fetch chats
-  const { error } = useQuery({
+  const { error } = useQuery<Chat[]>({
     queryKey: queryKeys.chats,
     queryFn: () => api.get<Chat[]>('/chats'),
     staleTime: 30000, // 30 seconds
@@ -48,7 +48,7 @@ export const Chats: React.FC = () => {
 
 
   // Delete chat mutation
-  const deleteMutation = useMutation({
+  const deleteMutation = useMutation<void, unknown, string>({
     mutationKey: mutationKeys.deleteChat(''),
     mutationFn: (chatId: string) => api.delete(`/chats/${chatId}`),
     onSuccess: () => {

--- a/frontend/src/pages/Documents.tsx
+++ b/frontend/src/pages/Documents.tsx
@@ -42,14 +42,14 @@ export const Documents: React.FC = () => {
   const queryClient = useQueryClient()
 
   // Fetch documents
-  const { data: documents = [], isLoading, error } = useQuery({
+  const { data: documents = [], isLoading, error } = useQuery<Document[]>({
     queryKey: queryKeys.documents,
     queryFn: () => api.get<Document[]>('/documents'),
     staleTime: 30000, // 30 seconds
   })
 
   // Delete document mutation
-  const deleteMutation = useMutation({
+  const deleteMutation = useMutation<void, unknown, string>({
     mutationKey: mutationKeys.deleteDocument(''),
     mutationFn: (documentId: string) => api.delete(`/documents/${documentId}`),
     onSuccess: () => {

--- a/frontend/src/pages/DomainDetails.tsx
+++ b/frontend/src/pages/DomainDetails.tsx
@@ -69,28 +69,28 @@ export const DomainDetails: React.FC = () => {
   const queryClient = useQueryClient()
 
   // Fetch domain details
-  const { data: domain, isLoading, error } = useQuery({
+  const { data: domain, isLoading, error } = useQuery<Domain>({
     queryKey: queryKeys.domain(id!),
     queryFn: () => api.get<Domain>(`/domains/${id}`),
     enabled: !!id,
   })
 
   // Fetch domain documents
-  const { data: documents = [] } = useQuery({
+  const { data: documents = [] } = useQuery<Document[]>({
     queryKey: ['domains', id, 'documents'],
     queryFn: () => api.get<Document[]>(`/domains/${id}/documents`),
     enabled: !!id,
   })
 
   // Fetch domain chats
-  const { data: chats = [] } = useQuery({
+  const { data: chats = [] } = useQuery<Chat[]>({
     queryKey: ['domains', id, 'chats'],
     queryFn: () => api.get<Chat[]>(`/domains/${id}/chats`),
     enabled: !!id,
   })
 
   // Delete domain mutation
-  const deleteMutation = useMutation({
+  const deleteMutation = useMutation<void, unknown>({
     mutationKey: mutationKeys.deleteDomain(id!),
     mutationFn: () => api.delete(`/domains/${id}`),
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- add a typed frontend `lib` layer for API access, routing helpers, query keys, and class name utilities
- update document upload flows to use the shared API client and provide typed progress/error handling
- tighten React Query usage across dashboard pages to satisfy strict TypeScript checks

## Testing
- npm run build -- --mode development

------
https://chatgpt.com/codex/tasks/task_e_68cc8ce6e4a08321a3f607e3eff63cea